### PR TITLE
work on #1; Change to MetaCPAN::Client from MetaCPAN::API

### DIFF
--- a/t/03-revdep.t
+++ b/t/03-revdep.t
@@ -1,10 +1,9 @@
-#!perl
-
+#!/usr/bin/perl
 use strict;
 use warnings;
 
-use Test::More 0.88 tests => 3;
 use CPAN::ReverseDependencies;
+use Test::More;
 
 my $crd = CPAN::ReverseDependencies->new();
 my @deps;
@@ -12,15 +11,17 @@ my @deps;
 ok(defined($crd), "create instance of CPAN::ReverseDependencies");
 
 SKIP: {
-    eval { @deps = $crd->get_reverse_dependencies('Module-Path'); };
+    eval { @deps = $crd->revdeps('Module-Path'); };
     skip("looks like you and/or MetaCPAN are offline", 1) if $@;
-    ok(grep({ $_ eq 'App-PrereqGrapher' } @deps), 
+    ok(grep({ $_ eq 'App-PrereqGrapher' } @deps),
        "check we got some dependents and App-PrereqGrapher was one of them");
 };
 
 SKIP: {
-    eval { @deps = $crd->get_reverse_dependencies('Module::Path'); };
+    eval { @deps = $crd->revdeps('Module::Path'); };
     skip("looks like you and/or MetaCPAN are offline", 1) if $@;
     ok(grep({ $_ eq 'App-PrereqGrapher' } @deps),
        "App::PrereqGrapher is included when module has ::");
 };
+done_testing();
+


### PR DESCRIPTION
- the latter is deprecated
- we can now specify module as 'Module-Name' or 'Module::Name'
- added revdeps(), which aliases get_reverse_dependencies()
